### PR TITLE
feat(nx-cloud): set up nx workspace

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -15,7 +15,7 @@
     "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
   },
   "nxCloudUrl": "https://staging.nx.app",
-  "nxCloudId": "678ff07458d9ba72cbae7c3f",
+  "nxCloudId": "679015950a65cf359ae5e47f",
   "plugins": [
     {
       "plugin": "@nx/next/plugin",


### PR DESCRIPTION
feat(nx-cloud): setup nx cloud workspace

This commit sets up Nx Cloud for your Nx workspace, enabling distributed caching and the Nx Cloud GitHub integration for fast CI and improved developer experience.

You can access your Nx Cloud workspace by going to
https://staging.nx.app/orgs/6790158558d9ba72cbae7c46/workspaces/679015950a65cf359ae5e47f

**Note:** This commit attempts to maintain formatting of the nx.json file, however you may need to correct formatting by running an nx format command and committing the changes.